### PR TITLE
Ignore lost winrm session error when trying destroy and instance

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -231,7 +231,13 @@ module Kitchen
 
         server = ec2.get_instance(state[:server_id])
         unless server.nil?
-          instance.transport.connection(state).close
+          begin
+            instance.transport.connection(state).close
+          rescue ex
+            # We don't care if this fails, and it does so regularly for an
+            # unknown reason
+            info("Error closing connection with message: #{ex}")
+          end
           server.terminate
         end
         if state[:spot_request_id]


### PR DESCRIPTION
Destroy actions regularly fail under certain conditions for no apparent
reason with the following error:

Failed to complete #destroy action: [[WSMAN ERROR CODE: 2150858843]:
<f:WSManFault Code='2150858843'
Machine='XXX.us-west-2.compute.amazonaws.com'
xmlns:f='http://schemas.microsoft.com/wbem/wsman/1/wsmanfault'><f:Message>The
request for the Windows Remote Shell with ShellId
0D060F3A-1FD9-4A51-BCAC-382CECDFA02C failed because the shell was not
found on the server. Possible causes are: the specified ShellId is
incorrect or the shell no longer exists on the server. Provide the
correct ShellId or create a new shell and retry the operation.
</f:Message></f:WSManFault>] on suite_name

As we are going to destroy the instance, this really only possibly
leads to some connections staying open but invalid