### PR TITLE
Don't crash upon destroy if instance is already dead

### DIFF
--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -241,7 +241,11 @@ module Kitchen
             # unknown reason
             info("Error closing connection with message: #{ex.class.name} #{ex.message} #{ex.backtrace}")
           end
-          server.terminate
+          begin
+            server.terminate
+          rescue ::Aws::EC2::Errors::InvalidInstanceIDNotFound => e
+            warn("Received #{e}, instance was probably already destroyed. Ignoring")
+          end
         end
         if state[:spot_request_id]
           debug("Deleting spot request <#{state[:server_id]}>")


### PR DESCRIPTION
In some VPCs , instances are automatically destroyed after a while
(to avoid leaking test instances that would be billed for a long time).

This patch ignores errors from ec2 when instance id is not found upon
destroy.

It will solve the long running issue where user runs `kitchen test` >1d
after running a `kitchen test --destroy=never` for instance